### PR TITLE
Bugfix for callback to iOS with string args containing slashes

### DIFF
--- a/js/communicator.js
+++ b/js/communicator.js
@@ -192,7 +192,7 @@ var WebViewCommunicator =  (function(){
 
     function native_call_ios(tag, method, callbackId, params) {
         function getURL(tag, method, params) {
-            var url = "js:WebViewCommunicator/" + tag + "/" + method + "/" + JSON.stringify(params);
+            var url = "js:WebViewCommunicator/" + tag + "/" + method + "/" + encodeURIComponent(JSON.stringify(params));
             return url;
         }
 


### PR DESCRIPTION
When communicating from JS to Obj-C, if there's some data that needs to be sent, 
if the data contains characters like \ in the JSON response,
since there was no url encoding done in the part of `communicator.js`, 
`shouldStartLoadWithRequest` converts to / (like how a browser does it). 
Therefore, all the JSON parsing was failing and the IOS method was not able to get that data.
This pull request fixes that for iOS only.

This also fixes a related bug, wherein if the resp argument contains escaped chars even after url decoding, then splitting it on \ would again fail at JSON parsing.
This pull request fixes that with just calling join on all the elements in the 3rd component.

PS: I have not added `encodeURIComponent` in the `native_call_android` method in the `communicator.js` file, since I couldn't test it out. But I think it would be needed.